### PR TITLE
[FIX] set_message_read() to set_message_done()

### DIFF
--- a/mail_move_message/mail_move_message_models.py
+++ b/mail_move_message/mail_move_message_models.py
@@ -231,8 +231,8 @@ class wizard(models.TransientModel):
 
     @api.one
     def read_close(self):
-        self.message_id.set_message_read(True)
-        self.message_id.child_ids.set_message_read(True)
+        self.message_id.set_message_done()
+        self.message_id.child_ids.set_message_done()
         return {'type': 'ir.actions.act_window_close'}
 
 


### PR DESCRIPTION
There is no `set_message_read()` on `mail.message` anymore. Instead use `set_message_done()`