### PR TITLE
[FIX] compatibility with 10.0

### DIFF
--- a/mail_move_message/controllers/main.py
+++ b/mail_move_message/controllers/main.py
@@ -3,10 +3,10 @@ from openerp.addons.web.controllers.main import DataSet
 from openerp.tools.translate import _
 from openerp import http
 from openerp.http import request
-import openerp
+from openerp.addons.bus.controllers.main import BusController
 
 
-class MailChatController(openerp.addons.bus.controllers.main.BusController):
+class MailChatController(BusController):
     # -----------------------------
     # Extends BUS Controller Poll
     # -----------------------------


### PR DESCRIPTION
Make compatible with odoo 10 way of loading modules.

Module produced following error:

```2016-11-14 08:54:56,733 1 DEBUG ? odoo.http: Loading mail_move_message
/usr/local/lib/python2.7/dist-packages/werkzeug/filesystem.py:63: BrokenFilesystemWarning: Detected a misconfigured UNIX filesystem: Will use UTF-8 as filesystem encoding instead of 'ANSI_X3.4-1968'
  BrokenFilesystemWarning)
2016-11-14 08:54:56,744 1 INFO ? werkzeug: 172.23.0.4 - - [14/Nov/2016 08:54:56] "GET /web/session/logout HTTP/1.0" 500 -
2016-11-14 08:54:56,754 1 ERROR ? werkzeug: Error on request:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 193, in run_wsgi
    execute(self.server.app)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 181, in execute
    application_iter = app(environ, start_response)
  File "/opt/odoo/odoo/service/server.py", line 246, in app
    return self.app(e, s)
  File "/opt/odoo/odoo/service/wsgi_server.py", line 182, in application
    return werkzeug.contrib.fixers.ProxyFix(application_unproxied)(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/contrib/fixers.py", line 152, in __call__
    return self.app(environ, start_response)
  File "/opt/odoo/odoo/service/wsgi_server.py", line 170, in application_unproxied
    result = handler(environ, start_response)
  File "/opt/odoo/odoo/http.py", line 1305, in __call__
    self.load_addons()
  File "/opt/odoo/odoo/http.py", line 1326, in load_addons
    m = __import__('odoo.addons.' + module)
  File "/opt/odoo/odoo/modules/module.py", line 81, in load_module
    execfile(modfile, new_mod.__dict__)
  File "/opt/thirdparty/addons/it-projects-llc/mail/mail_move_message/__init__.py", line 2, in <module>
    from . import controllers
  File "/opt/thirdparty/addons/it-projects-llc/mail/mail_move_message/controllers/__init__.py", line 2, in <module>
    from . import main
  File "/opt/thirdparty/addons/it-projects-llc/mail/mail_move_message/controllers/main.py", line 10, in <module>
    class MailChatController(openerp.addons.bus.controllers.main.BusController):
AttributeError: 'module' object has no attribute 'bus'
```