### PR TITLE
[FIX] compatibility with 10.0

### DIFF
--- a/mail_base/controllers/main.py
+++ b/mail_base/controllers/main.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from openerp.http import request
-import openerp
+from openerp.addons.bus.controllers.main import BusController
 
 
-class MailChatController(openerp.addons.bus.controllers.main.BusController):
+class MailChatController(BusController):
     # -----------------------------
     # Extends BUS Controller Poll
     # -----------------------------


### PR DESCRIPTION
Fix problem with loading openerp.addons.bus.controllers.main.BusController, resulting in a fatal error during init on Odoo 10.0.

```
  File "/opt/thirdparty/addons/it-projects-llc/mail/mail_base/controllers/main.py", line 7, in <module>
    class MailChatController(openerp.addons.bus.controllers.main.BusController):
AttributeError: 'module' object has no attribute 'bus'
```